### PR TITLE
Add New Fetcher

### DIFF
--- a/fetchers/ProxyscanFetcher.py
+++ b/fetchers/ProxyscanFetcher.py
@@ -1,0 +1,24 @@
+from .BaseFetcher import BaseFetcher
+import requests
+import time
+
+class ProxyscanFetcher(BaseFetcher):
+    """
+    https://www.proxyscan.io/api/proxy?last_check=9800&uptime=50&limit=20&_t={{ timestamp }}
+    """
+
+    def fetch(self):
+        """
+        执行一次爬取，返回一个数组，每个元素是(protocol, ip, port)，portocol是协议名称，目前主要为http
+        返回示例：[('http', '127.0.0.1', 8080), ('http', '127.0.0.1', 1234)]
+        """
+        proxies = []
+        # 此API为随机获取接口，获取策略为：重复取十次后去重
+        for _ in range(10):
+            url = "https://www.proxyscan.io/api/proxy?last_check=9800&uptime=50&limit=20&_t=" + str(time.time())
+            resp = requests.get(url).json()
+            for data in resp:
+                protocol = str.lower(data['Type'][0])
+                proxies.append((protocol, data['Ip'], data['Port']))
+        
+        return list(set(proxies))

--- a/fetchers/__init__.py
+++ b/fetchers/__init__.py
@@ -11,6 +11,7 @@ from .IP3366Fetcher import IP3366Fetcher
 from .JiangxianliFetcher import JiangxianliFetcher
 from .IHuanFetcher import IHuanFetcher
 from .IP89Fetcher import IP89Fetcher
+from .ProxyscanFetcher import ProxyscanFetcher
 
 fetchers = [
     Fetcher(name='uu-proxy.com', fetcher=UUFetcher),
@@ -21,4 +22,5 @@ fetchers = [
     Fetcher(name='ip.jiangxianli.com', fetcher=JiangxianliFetcher),
     Fetcher(name='ip.ihuan.me', fetcher=IHuanFetcher),
     Fetcher(name='www.89ip.cn', fetcher=IP89Fetcher),
+    Fetcher(name='www.proxyscan.io', fetcher=ProxyscanFetcher)
 ]


### PR DESCRIPTION
#2 新增针对`www.proxyscan.io`的爬取器

此网站代理效果不错，国内阿里某服务器部署一晚上情况如下：
|名称 | 当前可用代理数量 | 数据库中的代理数量 | 总共爬取代理数量 | 上次爬取代理数量 | 上次爬取时间|
|:--     |:--                           |:--                               |:--                            |:--                           |:--                    |
|www.proxyscan.io|	643|	1007|	12329|	157|	2021-05-26 20:27:33|

美国某服务器部署两天情况如下：
|名称 | 当前可用代理数量 | 数据库中的代理数量 | 总共爬取代理数量 | 上次爬取代理数量 | 上次爬取时间|
|:--     |:--                           |:--                               |:--                            |:--                           |:--                    |
|www.proxyscan.io | 728 | 1179 | 66124 | 167 | 2021-05-26 17:58:51|