### PR TITLE
bugfix & update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.7.0
 
 WORKDIR /proxy
 
-ADD . /proxy
+ADD requirements.txt /proxy
+RUN pip3 config set global.index-url https://mirrors.aliyun.com/pypi/simple/
 RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,10 @@ docker build --tag proxy_pool .
 3. 运行镜像
 
 ```bash
-docker run -p 5000:5000 -d proxy_pool
+docker run -p 5000:5000 -v /root/ProxyPoolWithUI:/proxy -d proxy_pool
 ```
+`/root/ProxyPoolWithUI`为clone下来的项目目录路径，请自行更改
+
 
 ## 使用代理
 

--- a/api/api.py
+++ b/api/api.py
@@ -1,8 +1,12 @@
 # encoding: utf-8
 
 import os
+import logging
 from flask import Flask
 from flask import jsonify, request, redirect, send_from_directory
+
+log = logging.getLogger('werkzeug')
+log.disabled = True
 
 try:
     from db import conn
@@ -123,9 +127,11 @@ def after_request(resp):
     return resp
 app.after_request(after_request)
 
-def main():
+def main(proc_lock):
+    if proc_lock is not None:
+        conn.set_proc_lock(proc_lock)
     # 因为默认sqlite3中，同一个数据库连接不能在多线程环境下使用，所以这里需要禁用flask的多线程
     app.run(host='0.0.0.0', port=5000, threaded=False)
 
 if __name__ == '__main__':
-    main()
+    main(None)

--- a/config.py
+++ b/config.py
@@ -17,16 +17,16 @@ PROC_FETCHER_SLEEP = 5 * 60
 PROC_VALIDATOR_SLEEP = 5
 
 # 验证器的配置参数
-VALIDATE_THREAD_NUM = 80 # 验证线程数量
+VALIDATE_THREAD_NUM = 200 # 验证线程数量
 # 验证器的逻辑是：
 # 使用代理访问 VALIDATE_URL 网站，超时时间设置为 VALIDATE_TIMEOUT
 # 如果没有超时：
 # 1、若选择的验证方式为GET：  返回的网页中包含 VALIDATE_KEYWORD 文字，那么就认为本次验证成功
 # 2、若选择的验证方式为HEAD： 返回的响应头中，对于的 VALIDATE_HEADER 响应字段内容包含 VALIDATE_KEYWORD 内容，那么就认为本次验证成功
 # 上述过程最多进行 VALIDATE_MAX_FAILS 次，只要有一次成功，就认为代理可用
-VALIDATE_URL = 'https://www.baidu.com'
-VALIDATE_METHOD = 'GET' # 验证方式，可选：GET、HEAD
-VALIDATE_HEADER = 'Server' # 仅用于HEAD验证方式，百度响应头Server字段KEYWORD可填：bfe
-VALIDATE_KEYWORD = '百度一下，你就知道'
+VALIDATE_URL = 'https://qq.com'
+VALIDATE_METHOD = 'HEAD' # 验证方式，可选：GET、HEAD
+VALIDATE_HEADER = 'location' # 仅用于HEAD验证方式，百度响应头Server字段KEYWORD可填：bfe
+VALIDATE_KEYWORD = 'www.qq.com'
 VALIDATE_TIMEOUT = 5 # 超时时间，单位s
 VALIDATE_MAX_FAILS = 3

--- a/db/Proxy.py
+++ b/db/Proxy.py
@@ -99,7 +99,7 @@ class Proxy(object):
             self.validated = True
             self.validate_date = datetime.datetime.now()
             self.validate_failed_cnt = 0
-            self.to_validate_date = datetime.datetime.now() + datetime.timedelta(minutes=5) # 5分钟之后继续验证
+            self.to_validate_date = datetime.datetime.now() + datetime.timedelta(minutes=10)  # 10分钟之后继续验证
             return False
         else:
             self.validated = False
@@ -107,10 +107,10 @@ class Proxy(object):
             self.validate_failed_cnt = self.validate_failed_cnt + 1
 
             # 验证失败的次数越多，距离下次验证的时间越长
-            delay_minutes = self.validate_failed_cnt * 5
+            delay_minutes = self.validate_failed_cnt * 10
             self.to_validate_date = datetime.datetime.now() + datetime.timedelta(minutes=delay_minutes)
 
-            if self.validate_failed_cnt >= 3:
+            if self.validate_failed_cnt >= 6:
                 return True
             else:
                 return False

--- a/main.py
+++ b/main.py
@@ -6,6 +6,10 @@ from multiprocessing import Process
 import time
 from proc import run_fetcher, run_validator
 from api import api
+import multiprocessing
+
+# 进程锁
+proc_lock = multiprocessing.Lock()
 
 class Item:
     def __init__(self, target, name):
@@ -23,7 +27,7 @@ def main():
     while True:
         for p in processes:
             if p.process is None:
-                p.process = Process(target=p.target, name=p.name, daemon=False)
+                p.process = Process(target=p.target, name=p.name, daemon=False, args=(proc_lock, ))
                 p.process.start()
                 print(f'启动{p.name}进程，pid={p.process.pid}')
                 p.start_time = time.time()
@@ -56,7 +60,7 @@ def citest():
         p.process.start()
         print(f'running {p.name}, pid={p.process.pid}')
         p.start_time = time.time()
-    
+
     time.sleep(10)
 
     for p in processes:


### PR DESCRIPTION
## 修复BUG：
### 1、sqlite并发读写问题
原：提供设置time.sleep设置延迟时间片供CPU调度，此方式不仅影响系统效率且并未解决并发问题。
现：通过线程锁与进程锁限制数据库读写，相比较原先，效率上得到了不错的提升

### 2、fetch卡死问题
#18  fix【Fetcher被超时卡住系统的情形】

### 3、移除无意义断言

### 4、解决验证器队列存在空挡问题
原：proc/run_validator.py
```
        if len(running_proxies) >= VALIDATE_THREAD_NUM:
            time.sleep(PROC_VALIDATOR_SLEEP)
            continue

        # 找一些新的待验证的代理放入队列中
        added_cnt = 0
        for proxy in conn.getToValidate(VALIDATE_THREAD_NUM):
```
导致：in_que存在数量小于 VALIDATE_THREAD_NUM 的情况，validate_thread被无意义阻塞。

## 其他更新：
### 1、新的默认配置
a) 验证器默认改用qq.com
原：默认百度，判断title
现：默认qq.com，判断响应头的location即可，网络占用非常小

b) 移除sleep后的性能提升填补
验证器线程：80->200
单条代理下次验证时间：5min->10min
单条代理最多验证失败次数：3->6（原3次易出现无效代理移除后被爬取器重新爬取再进行验证）

### 2、关闭Flask控制台输出
Flask控制台输出没啥用+碍事